### PR TITLE
Update to support newer arrayvec releases.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitterlemon"
 edition = "2018"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Simon Harris <simon@pearfalse.com>"]
 description = "An RLE-based encoder and decoder for bit streams."
 license = "MIT"
@@ -10,7 +10,7 @@ categories = ["compression"]
 keywords = ["rle", "bitstream", "pack"]
 
 [dependencies]
-arrayvec = ">= 0.4"
+arrayvec = ">= 0.7"
 
 [dev-dependencies]
-random = ">= 0.12"
+random = ">= 0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitterlemon"
 edition = "2018"
-version = "0.3.0"
+version = "0.2.4"
 authors = ["Simon Harris <simon@pearfalse.com>"]
 description = "An RLE-based encoder and decoder for bit streams."
 license = "MIT"

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,7 +1,6 @@
 //! Handles encoding of a Bitterlemon data stream.
 
-extern crate arrayvec;
-
+use arrayvec::ArrayVec;
 use std::fmt;
 
 /// Encodes a given bit stream into a compact byte representation.
@@ -276,7 +275,7 @@ mod test_run_builder {
 }
 
 
-type RunHolding = arrayvec::ArrayVec<[Run; 128]>;
+type RunHolding = ArrayVec<Run, 128>;
 
 trait RunHoldingExtensions {
 	fn bytes_as_frame(&self) -> (u8, u8);

--- a/src/test_encode_round_trip.rs
+++ b/src/test_encode_round_trip.rs
@@ -1,6 +1,6 @@
 //! Encodes a boolean stream, then decodes it, checking that the output matches the input
 
-use arrayvec;
+use arrayvec::ArrayVec;
 use random::Source;
 
 use crate::{
@@ -44,7 +44,7 @@ fn random_kilobyte() {
 	const RUN_COUNT : usize = 5000;
 
 	for _ in 0..RUN_COUNT {
-		let mut source = arrayvec::ArrayVec::<[_; DATA_SIZE]>::new();
+		let mut source = ArrayVec::<_, DATA_SIZE>::new();
 
 		for _ in 0..(DATA_SIZE / 64) {
 			let rand = rand_source.read_u64();


### PR DESCRIPTION
I cloned the repo and `cargo build` was broken.

Apparently arrayvec changed its API in 0.6.0, so I updated to reflect that change.
Bump arrayvec to 0.7.2
Bump random to 0.13.

```cargo build && cargo test``` works now.